### PR TITLE
docker push fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,12 +65,12 @@ jobs:
           version: v1
           args: mod -licenses -json -output bom-cyclonedx.json
 
-      - name: Generate SBOM (SPDX)
+      - name: Generate SBOM (SPDX) from source
         uses: anchore/sbom-action@v0
         with:
           format: spdx-json
           output-file: bom-spdx.json
-          image: ${{ steps.docker_build.outputs.imageid }}
+          path: .
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Rename SBOM generation step to 'Generate SBOM (SPDX) from source' and change anchore/sbom-action to use the repository path instead of the Docker image