### PR TITLE
docker push fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Grant write permission to repository contents in the docker GitHub workflow