### PR TITLE
removal of extra char

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,6 @@ cp config/config.sample.json config/config.json
 # Or use default config location
 ./bin/zipreport-server
 ```
-w
 
 ## Sponsors
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove an extraneous character line from the README sponsors section to improve formatting.