### PR TITLE
Switch Docker base image to Wolfi

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,9 +11,9 @@ on:
       - main
       - master
 
-  # rebuild weekly to pick up base image and dependency security patches
+  # rebuild daily to pick up base image and dependency security patches
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * *'
 
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ browser-update
 
 # Test binary, built with `go test -c`
 *.test
+!Dockerfile.test
 
 # Output of the go coverage tool
 *.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated Go toolchain from 1.24.12 to 1.26.3
-- Upgraded Docker base image from Ubuntu 22.04 (Jammy) to 26.04 (Resolute)
-- Added `apt-get upgrade` to Dockerfile to apply all available OS security patches at build time
+- Switched Docker runtime base image from Ubuntu to Wolfi (`cgr.dev/chainguard/wolfi-base`); Chrome runtime
+  dependencies are now installed via `apk` (requires `libudev` and Mozilla NSS via `libnss`)
+- Rebased `Dockerfile.test` onto Wolfi with the `go-1.26` toolchain to match the runtime environment
 - Updated all GitHub Actions to Node.js 24 compatible versions (checkout v6, setup-go v6, build-push-action v7, etc.)
 - Replaced `CycloneDX/gh-gomod-generate-sbom` action with direct `cyclonedx-gomod` CLI (no Node.js 24 version available)
 - Replaced source-based SBOMs with image-based SBOMs in Docker workflow, capturing OS packages and runtime dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,12 @@ counter to prevent conflicts.
 
 ### Docker Environment
 
-The production Dockerfile uses a two-stage build: Go builder → Ubuntu runtime with Chrome dependencies. Chrome sandbox
-is disabled inside containers (detected via `/.dockerenv` file). The `browser-update` tool downloads the correct
-Chromium version at build time.
+The production Dockerfile uses a two-stage build: Go builder → Wolfi (`cgr.dev/chainguard/wolfi-base`) runtime with
+Chrome dependencies. Wolfi is glibc-based, so the glibc Chromium that `browser-update` downloads runs unmodified.
+Chrome runtime libs are pulled via `apk` (notably `libudev`, without which Chrome aborts at startup, and `libnss` for
+Mozilla NSS — Wolfi's `nss` package is glibc Name Service Switch, not NSS). Chrome sandbox is disabled inside
+containers (detected via `/.dockerenv` file). The `browser-update` tool downloads the correct Chromium version at
+build time.
 
 **Multi-platform support**: Docker images are built for `linux/amd64` and `linux/arm64`. The builder stage uses
 `--platform=$BUILDPLATFORM` with cross-compilation (`CGO_ENABLED=0 GOOS/GOARCH`) to avoid slow QEMU emulation. Chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,21 +19,39 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o browser-update ./cmd/browser-update/main.go && \
     mkdir -p /app/config/ssl
 
-FROM ubuntu:26.04
+FROM cgr.dev/chainguard/wolfi-base
 
 LABEL org.opencontainers.image.source=https://github.com/zipreport/zipreport-server
 
-RUN apt-get update > /dev/null && \
-    apt-get upgrade -y > /dev/null && \
-    apt-get install --no-install-recommends -y \
-    libnss3 libxss1 libasound2t64 libxtst6 libgtk-3-0t64 libgbm1 \
-    ca-certificates \
-    fonts-liberation fonts-noto-color-emoji fonts-noto-cjk \
+# Wolfi is glibc-based, so the glibc Chromium build downloaded by browser-update runs unmodified.
+# shadow provides useradd; the rest are Chromium's runtime libraries. libudev is required or
+# Chrome aborts at startup (udev_loader.cc); libnss is Mozilla NSS (Wolfi's "nss" is glibc NSS).
+RUN apk add --no-cache \
+    shadow \
+    libnss \
+    libudev \
+    libxscrnsaver \
+    libxtst \
+    libxcomposite \
+    libxdamage \
+    libxrandr \
+    libxkbcommon \
+    libx11 \
+    libdrm \
+    mesa-gbm \
+    gtk-3 \
+    pango \
+    cups-libs \
+    at-spi2-core \
+    dbus-libs \
+    alsa-lib \
+    ca-certificates-bundle \
+    font-liberation \
+    font-noto-emoji \
+    font-noto-cjk \
     tzdata \
     dumb-init \
-    xvfb \
-    > /dev/null && \
-    rm -rf /var/lib/apt/lists/*
+    xvfb-run
 
 WORKDIR /app
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,47 @@
+FROM cgr.dev/chainguard/wolfi-base
+
+# Go toolchain + git for module fetches, plus Chromium runtime libraries.
+# Package set mirrors the runtime Dockerfile.
+RUN apk add --no-cache \
+    go-1.26 \
+    git \
+    libnss \
+    libudev \
+    libxscrnsaver \
+    libxtst \
+    libxcomposite \
+    libxdamage \
+    libxrandr \
+    libxkbcommon \
+    libx11 \
+    libdrm \
+    mesa-gbm \
+    gtk-3 \
+    pango \
+    cups-libs \
+    at-spi2-core \
+    dbus-libs \
+    alsa-lib \
+    ca-certificates-bundle \
+    font-liberation \
+    font-noto-emoji \
+    font-noto-cjk \
+    tzdata
+
+ENV PATH="/usr/lib/go-1.26/bin:${PATH}"
+
+WORKDIR /app
+
+# Cache dependency downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build browser-update to fetch Chrome
+COPY . .
+RUN go build -ldflags="-s -w" -o browser-update ./cmd/browser-update/main.go && \
+    ./browser-update
+
+# Mark as Docker environment for --no-sandbox detection
+RUN touch /.dockerenv
+
+CMD ["go", "test", "-v", "-p", "1", "-timeout=10m", "./test/..."]

--- a/pkg/render/engine.go
+++ b/pkg/render/engine.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"zipreport-server/pkg/browser"
 	"zipreport-server/pkg/monitor"
 	"zipreport-server/pkg/zpt"
 
@@ -43,6 +44,11 @@ func NewEngine(ctx context.Context, concurrency int, basePort int, m *monitor.Me
 	if needsNoSandbox() {
 		logger.Info("Detected CI/Docker environment, launching Chrome with --no-sandbox")
 		l := launcher.New().NoSandbox(true)
+		if browser.IsInstalled() {
+			// Pin the pre-installed binary so rod skips its Validate() probe,
+			// which otherwise deletes and re-downloads Chromium at runtime.
+			l = l.Bin(browser.BinPath())
+		}
 		launcherURL = l.MustLaunch()
 	}
 


### PR DESCRIPTION
## Summary

Migrates the production and test Docker images from Ubuntu to Wolfi (`cgr.dev/chainguard/wolfi-base`) for a near-zero-CVE OS base, fixes a runtime Chromium re-download, and switches the image rebuild cron to daily.

## Changes

- **Wolfi base image** (`d5c8a28`) — `Dockerfile` and `Dockerfile.test` rebased onto `cgr.dev/chainguard/wolfi-base`. Wolfi is glibc-based, so the glibc Chromium fetched by `browser-update` runs unmodified. Chrome runtime deps installed via `apk`; notably `libudev` (Chrome aborts at startup without it — `udev_loader.cc`) and `libnss` for Mozilla NSS (Wolfi's `nss` package is glibc Name Service Switch, not NSS). `Dockerfile.test` is now tracked (was caught by the `*.test` gitignore rule).
- **No runtime Chromium download** (`89560af`) — rod's launcher validated the browser by *executing* it (`--dump-dom`); when the probe didn't return the exact expected DOM it deleted the cached binary and re-downloaded on first render. Pinning `launcher.Bin()` to the pre-installed path bypasses validation entirely. Cuts ~5s off cold start and works offline.
- **Daily image rebuild** (`459c35c`) — `docker.yml` cron changed from weekly to daily to pick up base-image/dependency patches faster, fitting the rolling Wolfi base.

## Verification

- Full integration suite passes inside the Wolfi environment (`ok zipreport-server/test`, all tests green: page sizes, JS-event mode, concurrency, path-traversal, metrics, SSL, timeout).
- End-to-end render of fixtures produces valid PDFs (`HTTP 200`, `application/pdf`).
- Confirmed no `Download:` lines in container logs on first render after the binary-pin fix.

## Notes / not covered

- Only `linux/amd64` was built/run locally. CI builds `linux/amd64,linux/arm64`; the arch-specific Chromium sourcing lives in the `browser-update` Go binary (base-image-agnostic), so arm64 should hold but is unverified here.
- Wolfi's apk packages are not pinned, consistent with the existing rebuild-to-patch model.

## Summary by Sourcery

Switch the runtime Docker images to a Wolfi-based environment and improve Chrome/Chromium handling and image rebuild cadence.

Bug Fixes:
- Prevent Chromium from being re-downloaded at runtime by pinning the launcher to the pre-installed browser binary when available.

Enhancements:
- Migrate the production Docker runtime image from Ubuntu to Wolfi, installing Chrome runtime dependencies via apk, including required libudev and Mozilla NSS libraries.
- Align the test Docker image with the Wolfi base and Go 1.26 toolchain to mirror the production runtime environment.

Build:
- Add a Wolfi-based test Dockerfile and adjust dependencies for the new base image.

CI:
- Increase Docker image rebuild frequency from weekly to daily in the GitHub Actions workflow to pick up base-image and dependency patches faster.

Documentation:
- Update Docker environment and changelog documentation to reflect the Wolfi base image and new Chrome dependency handling.