### PR TITLE
fix(ci): correct trivy-action tag to v0.36.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
           provenance: true
 
       - name: Scan Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.71.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_IGNORE_UNFIXED: 'true'
         with:


### PR DESCRIPTION
## Problem

The `Build and publish a Docker image to ghcr.io` workflow fails at setup in ~7s:

```
##[error]Unable to resolve action `aquasecurity/trivy-action@v0.71.0`, unable to find version `v0.71.0`
```

The "fix: pin Wolfi base image tag and update Trivy action" change bumped `trivy-action` to `v0.71.0`, but that tag does not exist — the latest `aquasecurity/trivy-action` tag is `v0.36.0`. `0.71` is the Trivy *CLI* version, not the action version.

## Fix

Revert the action tag to `v0.36.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the Trivy vulnerability scanning GitHub Action in the Docker workflow to use the existing v0.36.0 tag instead of the non-existent v0.71.0.