### PR TITLE
chore(deps): go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/oddbit-project/blueprint/provider/httpserver v0.9.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
-	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -60,6 +59,7 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/redis/go-redis/v9 v9.20.0 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/ysmood/fetchup v0.5.3 // indirect


### PR DESCRIPTION
Fixes the failing **go mod tidy** check. `github.com/rs/zerolog` was listed as a direct dependency in `go.mod` but is no longer imported directly, so `go mod tidy` moves it to the indirect require block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Move github.com/rs/zerolog from direct to indirect dependency in go.mod to reflect that it is no longer imported directly.