### PR TITLE
ci(docker): add no_cache dispatch input for fresh-base rebuild

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,11 @@ on:
     - cron: '0 6 * * *'
 
   workflow_dispatch:
+    inputs:
+      no_cache:
+        description: 'Build without layer cache to pick up fresh base image / package patches'
+        type: boolean
+        default: false
 
 jobs:
   docker_publish:
@@ -62,6 +67,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
+          no-cache: ${{ inputs.no_cache || false }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Adds a `no_cache` `workflow_dispatch` input wired to `build-push-action`'s `no-cache`.

The gha layer cache reuses the `apk add` layer, so a plain re-run reinstalls the same (vulnerable) package versions even after Wolfi publishes patches. With this, a manual run can be triggered with `no_cache=true` to rebuild from a fresh base and pick up fixed packages — useful for clearing Trivy CRITICAL findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Introduce a boolean no_cache workflow_dispatch input and wire it to the Docker build no-cache flag for manual cache-busting builds.