### PR TITLE
ci(docker): daily scheduled rebuild without cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-          no-cache: ${{ inputs.no_cache || false }}
+          no-cache: ${{ inputs.no_cache || github.event_name == 'schedule' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The daily `schedule` rebuild is meant to pick up base-image/package security patches, but `cache-from/to: type=gha,mode=max` reused the `apk add` layer and reinstalled the same package versions — defeating the purpose.

This forces `no-cache` on `schedule` events (manual `no_cache` input still honored), so the daily run always rebuilds from a fresh Wolfi base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Change the Docker GitHub Actions workflow to disable build cache on scheduled runs while still honoring the manual no_cache input.